### PR TITLE
Fix view matrix integration

### DIFF
--- a/includes/Human/Arm.hpp
+++ b/includes/Human/Arm.hpp
@@ -14,7 +14,7 @@ public:
     Arm(float x, float y, float z);
     virtual ~Arm() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
     
     // Arm rotation methods
     void setUpperArmRotation(float x, float z);

--- a/includes/Human/BodyPart.hpp
+++ b/includes/Human/BodyPart.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../humangl.hpp"
+#include "../Matrix/MatrixStack.hpp"
 
 // Base class for all body part renderers
 class BodyPartRenderer {
@@ -12,7 +13,7 @@ public:
     virtual ~BodyPartRenderer() = default;
 
     // Pure virtual render method
-    virtual void render() = 0;
+    virtual void render(MatrixStack& matrixStack) = 0;
 
     // Color management
     void setColor(float r, float g, float b);

--- a/includes/Human/DrawPerson.hpp
+++ b/includes/Human/DrawPerson.hpp
@@ -29,7 +29,7 @@ public:
     ~DrawPerson() = default;
 
     // Main render method
-    void render();
+    void render(MatrixStack& matrixStack);
 
     // Global transformation methods
     void setTorsoRotation(float y);

--- a/includes/Human/Head.hpp
+++ b/includes/Human/Head.hpp
@@ -9,7 +9,7 @@ public:
     Torso();
     virtual ~Torso() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
 };
 
 // Neck class
@@ -18,7 +18,7 @@ public:
     Neck();
     virtual ~Neck() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
 };
 
 // Head class
@@ -31,7 +31,7 @@ public:
     Head();
     virtual ~Head() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
     
     // Head-specific rotation methods
     void setHeadRotation(float x, float y);
@@ -48,7 +48,7 @@ public:
     Eyes();
     virtual ~Eyes() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
     
     // Sync with head rotation
     void setHeadRotation(float x, float y);

--- a/includes/Human/Leg.hpp
+++ b/includes/Human/Leg.hpp
@@ -14,7 +14,7 @@ public:
     Leg(float x, float y, float z);
     virtual ~Leg() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
     
     // Leg rotation methods
     void setThighRotation(float x);

--- a/includes/Human/Shoulder.hpp
+++ b/includes/Human/Shoulder.hpp
@@ -12,7 +12,7 @@ public:
     Shoulder(float x, float y, float z);
     virtual ~Shoulder() = default;
 
-    void render() override;
+    void render(MatrixStack& matrixStack) override;
 };
 
 // Left Shoulder class

--- a/includes/Input/KeyboardHandler.hpp
+++ b/includes/Input/KeyboardHandler.hpp
@@ -3,6 +3,7 @@
 #include "../Human/DrawPerson.hpp"
 #include "../humangl.hpp"
 #include "../Simulation/AnimationManager.hpp"
+#include "../Matrix/Matrix4.hpp"
 
 class KeyboardHandler {
 private:
@@ -31,6 +32,9 @@ public:
     // Camera control methods
     void handleCameraControls();
     void applyCameraTransform();
+
+    // Build view matrix from camera parameters
+    Matrix4 getViewMatrix() const;
     
     // Camera getters
     float getCameraRotationY() const { return cameraRotationY; }

--- a/includes/Matrix/Matrix4.hpp
+++ b/includes/Matrix/Matrix4.hpp
@@ -26,4 +26,7 @@ public:
 
     // Apply matrix to OpenGL
     void applyToOpenGL() const;
+
+    // Access raw data for custom OpenGL loading
+    const float* data() const { return m; }
 };

--- a/includes/Matrix/MatrixStack.hpp
+++ b/includes/Matrix/MatrixStack.hpp
@@ -7,6 +7,7 @@ class MatrixStack {
 private:
     std::vector<Matrix4> stack;
     Matrix4 current;
+    Matrix4 viewMatrix;
 
 public:
     // Constructor - initializes with identity matrix
@@ -28,4 +29,7 @@ public:
 
     // Apply current matrix to OpenGL
     void applyToOpenGL();
+
+    // Set view matrix (camera transform)
+    void setViewMatrix(const Matrix4& view);
 };

--- a/includes/Simulation/SimulationRenderer.hpp
+++ b/includes/Simulation/SimulationRenderer.hpp
@@ -3,9 +3,11 @@
 #include "../humangl.hpp"
 #include "../Human/DrawPerson.hpp"
 #include "../Input/KeyboardHandler.hpp"
+#include "../Matrix/MatrixStack.hpp"
 
 class SimulationRenderer {
 private:
+    MatrixStack& matrixStack;
     DrawPerson& drawPerson;
     KeyboardHandler& keyboardHandler;
     
@@ -17,7 +19,7 @@ private:
     int windowHeight;
 
 public:
-    SimulationRenderer(DrawPerson& person, KeyboardHandler& kbHandler, int winWidth, int winHeight);
+    SimulationRenderer(MatrixStack& stack, DrawPerson& person, KeyboardHandler& kbHandler, int winWidth, int winHeight);
     ~SimulationRenderer() = default;
 
     // Main rendering method

--- a/sources/Application/Application.cpp
+++ b/sources/Application/Application.cpp
@@ -6,7 +6,7 @@ Application::Application()
       currentState(MAIN_MENU),
       keyboardHandler(drawPerson),
       animationManager(drawPerson),
-      simulationRenderer(drawPerson, keyboardHandler, windowWidth, windowHeight),
+      simulationRenderer(matrixStack, drawPerson, keyboardHandler, windowWidth, windowHeight),
       eventHandler(animationManager, keyboardHandler, menuSystem, simulationRenderer, 
                    &currentState, windowWidth, windowHeight),
       currentAnimation(NONE), animationTime(0.0f), jumpHeight(0.0f),

--- a/sources/Human/Arm.cpp
+++ b/sources/Human/Arm.cpp
@@ -6,28 +6,30 @@ Arm::Arm(float x, float y, float z)
     // Skin color for arms
 }
 
-void Arm::render() {
+void Arm::render(MatrixStack& matrixStack) {
     // Draw the entire arm as a connected hierarchy
-    glPushMatrix();
-    glTranslatef(positionX, positionY, positionZ);
-    glRotatef(upperArmX, 1.0f, 0.0f, 0.0f);
-    glRotatef(upperArmZ, 0.0f, 0.0f, 1.0f);
+    matrixStack.pushMatrix();
+    matrixStack.translate(positionX, positionY, positionZ);
+    matrixStack.rotateX(upperArmX);
+    matrixStack.rotateZ(upperArmZ);
 
     // Draw upper arm
-    glPushMatrix();
-    glTranslatef(0.0f, -0.4f, 0.0f);
-    glScalef(0.3f, 0.8f, 0.3f);
+    matrixStack.pushMatrix();
+    matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.3f, 0.8f, 0.3f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);  // Skin color for upper arms
-    glPopMatrix();
+    matrixStack.popMatrix();
 
     // Draw forearm (connected to upper arm)
-    glTranslatef(0.0f, -0.8f, 0.0f);
-    glRotatef(forearmX, 1.0f, 0.0f, 0.0f);
-    glTranslatef(0.0f, -0.4f, 0.0f);
-    glScalef(0.25f, 0.8f, 0.25f);
+    matrixStack.translate(0.0f, -0.8f, 0.0f);
+    matrixStack.rotateX(forearmX);
+    matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.25f, 0.8f, 0.25f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);  // Skin color for forearms
 
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 void Arm::setUpperArmRotation(float x, float z) {

--- a/sources/Human/DrawPerson.cpp
+++ b/sources/Human/DrawPerson.cpp
@@ -14,39 +14,39 @@ DrawPerson::DrawPerson() : torsoRotationY(0.0f), jumpHeight(0.0f) {
     rightLeg = std::make_unique<RightLeg>();
 }
 
-void DrawPerson::render() {
+void DrawPerson::render(MatrixStack& matrixStack) {
     // Enable face culling for better performance
     glEnable(GL_CULL_FACE);
     glCullFace(GL_BACK);
 
     // Apply global transformations
-    glPushMatrix();
+    matrixStack.pushMatrix();
 
     // Apply jump height (affects entire body)
-    glTranslatef(0.0f, jumpHeight, 0.0f);
+    matrixStack.translate(0.0f, jumpHeight, 0.0f);
 
     // Apply torso rotation (this affects all body parts)
-    glRotatef(torsoRotationY, 0.0f, 1.0f, 0.0f);
+    matrixStack.rotateY(torsoRotationY);
 
     // Draw body parts in hierarchical order
-    torso->render();           // Base of hierarchy
-    neck->render();            // Connected to torso
-    head->render();            // Connected to neck
-    eyes->render();            // Eyes on the head (shows front direction)
+    torso->render(matrixStack);           // Base of hierarchy
+    neck->render(matrixStack);            // Connected to torso
+    head->render(matrixStack);            // Connected to neck
+    eyes->render(matrixStack);            // Eyes on the head (shows front direction)
 
     // Draw shoulder joints
-    leftShoulder->render();    // Left shoulder joint
-    rightShoulder->render();   // Right shoulder joint
+    leftShoulder->render(matrixStack);    // Left shoulder joint
+    rightShoulder->render(matrixStack);   // Right shoulder joint
 
     // Draw arms (connected to shoulders)
-    leftArm->render();         // Left arm (upper arm + forearm connected)
-    rightArm->render();        // Right arm (upper arm + forearm connected)
+    leftArm->render(matrixStack);         // Left arm (upper arm + forearm connected)
+    rightArm->render(matrixStack);        // Right arm (upper arm + forearm connected)
 
     // Draw legs (connected to torso)
-    leftLeg->render();         // Left leg (thigh + lower leg connected)
-    rightLeg->render();        // Right leg (thigh + lower leg connected)
+    leftLeg->render(matrixStack);         // Left leg (thigh + lower leg connected)
+    rightLeg->render(matrixStack);        // Right leg (thigh + lower leg connected)
 
-    glPopMatrix();
+    matrixStack.popMatrix();
 
     // Disable states we enabled
     glDisable(GL_CULL_FACE);

--- a/sources/Human/Head.cpp
+++ b/sources/Human/Head.cpp
@@ -5,37 +5,40 @@ Torso::Torso() : BodyPartRenderer(0.2f, 0.4f, 0.8f) {
     // Blue shirt color
 }
 
-void Torso::render() {
-    glPushMatrix();
-    glScalef(1.0f, 1.5f, 0.5f);
+void Torso::render(MatrixStack& matrixStack) {
+    matrixStack.pushMatrix();
+    matrixStack.scale(1.0f, 1.5f, 0.5f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 Neck::Neck() : BodyPartRenderer(0.8f, 0.6f, 0.4f) {
     // Skin color
 }
 
-void Neck::render() {
-    glPushMatrix();
-    glTranslatef(0.0f, 0.9f, 0.0f);
-    glScalef(0.3f, 0.3f, 0.3f);
+void Neck::render(MatrixStack& matrixStack) {
+    matrixStack.pushMatrix();
+    matrixStack.translate(0.0f, 0.9f, 0.0f);
+    matrixStack.scale(0.3f, 0.3f, 0.3f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 Head::Head() : BodyPartRenderer(0.8f, 0.6f, 0.4f), headRotationX(0.0f), headRotationY(0.0f) {
     // Skin color
 }
 
-void Head::render() {
-    glPushMatrix();
-    glTranslatef(0.0f, 1.4f, 0.0f);
-    glRotatef(headRotationX, 1.0f, 0.0f, 0.0f);
-    glRotatef(headRotationY, 0.0f, 1.0f, 0.0f);
-    glScalef(0.6f, 0.6f, 0.6f);
+void Head::render(MatrixStack& matrixStack) {
+    matrixStack.pushMatrix();
+    matrixStack.translate(0.0f, 1.4f, 0.0f);
+    matrixStack.rotateX(headRotationX);
+    matrixStack.rotateY(headRotationY);
+    matrixStack.scale(0.6f, 0.6f, 0.6f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 void Head::setHeadRotation(float x, float y) {
@@ -52,27 +55,29 @@ Eyes::Eyes() : BodyPartRenderer(0.0f, 0.0f, 0.0f), headRotationX(0.0f), headRota
     // Black color for eyes
 }
 
-void Eyes::render() {
-    glPushMatrix();
-    glTranslatef(0.0f, 1.4f, 0.0f);
-    glRotatef(headRotationX, 1.0f, 0.0f, 0.0f);
-    glRotatef(headRotationY, 0.0f, 1.0f, 0.0f);
+void Eyes::render(MatrixStack& matrixStack) {
+    matrixStack.pushMatrix();
+    matrixStack.translate(0.0f, 1.4f, 0.0f);
+    matrixStack.rotateX(headRotationX);
+    matrixStack.rotateY(headRotationY);
 
     // Left eye
-    glPushMatrix();
-    glTranslatef(-0.15f, 0.1f, 0.31f);
-    glScalef(0.1f, 0.1f, 0.1f);
+    matrixStack.pushMatrix();
+    matrixStack.translate(-0.15f, 0.1f, 0.31f);
+    matrixStack.scale(0.1f, 0.1f, 0.1f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
-    glPopMatrix();
+    matrixStack.popMatrix();
 
     // Right eye
-    glPushMatrix();
-    glTranslatef(0.15f, 0.1f, 0.31f);
-    glScalef(0.1f, 0.1f, 0.1f);
+    matrixStack.pushMatrix();
+    matrixStack.translate(0.15f, 0.1f, 0.31f);
+    matrixStack.scale(0.1f, 0.1f, 0.1f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
-    glPopMatrix();
+    matrixStack.popMatrix();
 
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 void Eyes::setHeadRotation(float x, float y) {

--- a/sources/Human/Leg.cpp
+++ b/sources/Human/Leg.cpp
@@ -6,27 +6,29 @@ Leg::Leg(float x, float y, float z)
     // Skin color for legs (will be overridden for thighs with pants color)
 }
 
-void Leg::render() {
+void Leg::render(MatrixStack& matrixStack) {
     // Draw the entire leg as a connected hierarchy
-    glPushMatrix();
-    glTranslatef(positionX, positionY, positionZ);
-    glRotatef(thighX, 1.0f, 0.0f, 0.0f);
+    matrixStack.pushMatrix();
+    matrixStack.translate(positionX, positionY, positionZ);
+    matrixStack.rotateX(thighX);
 
     // Draw thigh (with pants color)
-    glPushMatrix();
-    glTranslatef(0.0f, -0.4f, 0.0f);
-    glScalef(0.3f, 0.8f, 0.3f);
+    matrixStack.pushMatrix();
+    matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.3f, 0.8f, 0.3f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(0.1f, 0.2f, 0.6f);  // Dark blue pants color for thighs
-    glPopMatrix();
+    matrixStack.popMatrix();
 
     // Draw lower leg (connected to thigh)
-    glTranslatef(0.0f, -0.8f, 0.0f);
-    glRotatef(lowerLegX, 1.0f, 0.0f, 0.0f);
-    glTranslatef(0.0f, -0.4f, 0.0f);
-    glScalef(0.25f, 0.8f, 0.25f);
+    matrixStack.translate(0.0f, -0.8f, 0.0f);
+    matrixStack.rotateX(lowerLegX);
+    matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.25f, 0.8f, 0.25f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);  // Skin color for lower legs
 
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 void Leg::setThighRotation(float x) {

--- a/sources/Human/Shoulder.cpp
+++ b/sources/Human/Shoulder.cpp
@@ -5,12 +5,13 @@ Shoulder::Shoulder(float x, float y, float z)
     // Blue shirt color for shoulders
 }
 
-void Shoulder::render() {
-    glPushMatrix();
-    glTranslatef(positionX, positionY, positionZ);
-    glScalef(0.3f, 0.3f, 0.3f);
+void Shoulder::render(MatrixStack& matrixStack) {
+    matrixStack.pushMatrix();
+    matrixStack.translate(positionX, positionY, positionZ);
+    matrixStack.scale(0.3f, 0.3f, 0.3f);
+    matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
-    glPopMatrix();
+    matrixStack.popMatrix();
 }
 
 LeftShoulder::LeftShoulder() : Shoulder(-0.7f, 0.5f, 0.0f) {

--- a/sources/Input/KeyboardHandler.cpp
+++ b/sources/Input/KeyboardHandler.cpp
@@ -161,6 +161,13 @@ void KeyboardHandler::applyCameraTransform() {
     glRotatef(cameraRotationY, 0.0f, 1.0f, 0.0f);
 }
 
+Matrix4 KeyboardHandler::getViewMatrix() const {
+    Matrix4 view;
+    view.translate(0.0f, cameraHeight, -cameraDistance);
+    view.rotateY(cameraRotationY);
+    return view;
+}
+
 void KeyboardHandler::resetCameraPosition() {
     // Reset camera to default position
     cameraRotationY = 0.0f;

--- a/sources/Matrix/MatrixStack.cpp
+++ b/sources/Matrix/MatrixStack.cpp
@@ -2,6 +2,7 @@
 
 MatrixStack::MatrixStack() {
     current.loadIdentity();
+    viewMatrix.loadIdentity();
 }
 
 void MatrixStack::loadIdentity() {
@@ -40,6 +41,10 @@ void MatrixStack::scale(float x, float y, float z) {
 }
 
 void MatrixStack::applyToOpenGL() {
-    glLoadIdentity();
-    current.applyToOpenGL();
+    Matrix4 combined = viewMatrix * current;
+    glLoadMatrixf(combined.data());
+}
+
+void MatrixStack::setViewMatrix(const Matrix4& view) {
+    viewMatrix = view;
 }

--- a/sources/Simulation/SimulationRenderer.cpp
+++ b/sources/Simulation/SimulationRenderer.cpp
@@ -1,7 +1,7 @@
 #include "../../includes/Simulation/SimulationRenderer.hpp"
 
-SimulationRenderer::SimulationRenderer(DrawPerson& person, KeyboardHandler& kbHandler, int winWidth, int winHeight)
-    : drawPerson(person), keyboardHandler(kbHandler),
+SimulationRenderer::SimulationRenderer(MatrixStack& stack, DrawPerson& person, KeyboardHandler& kbHandler, int winWidth, int winHeight)
+    : matrixStack(stack), drawPerson(person), keyboardHandler(kbHandler),
       nearPlane(1.0f), farPlane(100.0f), fov(45.0f),
       windowWidth(winWidth), windowHeight(winHeight) {
 }
@@ -15,11 +15,13 @@ void SimulationRenderer::render() {
     setupLighting();
     setupScene();
     
-    // Apply camera transformations
-    keyboardHandler.applyCameraTransform();
-    
+    // Build view matrix from camera parameters
+    Matrix4 view = keyboardHandler.getViewMatrix();
+    matrixStack.setViewMatrix(view);
+    matrixStack.loadIdentity();
+
     // Render the person
-    drawPerson.render();
+    drawPerson.render(matrixStack);
 }
 
 void SimulationRenderer::setupPerspective() {


### PR DESCRIPTION
## Summary
- add data() accessor to Matrix4
- store camera view matrix in MatrixStack and apply during rendering
- compute view matrix via KeyboardHandler
- set view matrix each frame in SimulationRenderer

## Testing
- `make` *(fails: SDL2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878e7bfaa288331b7e5900a8532e4f0