### PR TITLE
Fix joint offsets and add debug markers

### DIFF
--- a/sources/Human/Arm.cpp
+++ b/sources/Human/Arm.cpp
@@ -10,6 +10,14 @@ void Arm::render(MatrixStack& matrixStack) {
     // Draw the entire arm as a connected hierarchy
     matrixStack.pushMatrix();
     matrixStack.translate(positionX, positionY, positionZ);
+
+    // Debug marker to visualize the shoulder joint position
+    matrixStack.pushMatrix();
+    matrixStack.scale(0.05f, 0.05f, 0.05f);
+    matrixStack.applyToOpenGL();
+    drawColoredCube(1.0f, 0.0f, 0.0f); // bright red cube
+    matrixStack.popMatrix();
+
     matrixStack.rotateX(upperArmX);
     matrixStack.rotateZ(upperArmZ);
 
@@ -51,8 +59,8 @@ void Arm::getForearmRotation(float& x) const {
 }
 
 /* Left and Right Arm */
-LeftArm::LeftArm() : Arm(-0.7f, 0.5f, 0.0f) {
+LeftArm::LeftArm() : Arm(-0.6f, 1.2f, 0.0f) {
 }
 
-RightArm::RightArm() : Arm(0.7f, 0.5f, 0.0f) {
+RightArm::RightArm() : Arm(0.6f, 1.2f, 0.0f) {
 }

--- a/sources/Human/Leg.cpp
+++ b/sources/Human/Leg.cpp
@@ -10,6 +10,14 @@ void Leg::render(MatrixStack& matrixStack) {
     // Draw the entire leg as a connected hierarchy
     matrixStack.pushMatrix();
     matrixStack.translate(positionX, positionY, positionZ);
+
+    // Debug marker to visualize the hip joint position
+    matrixStack.pushMatrix();
+    matrixStack.scale(0.05f, 0.05f, 0.05f);
+    matrixStack.applyToOpenGL();
+    drawColoredCube(1.0f, 0.0f, 0.0f); // bright red cube
+    matrixStack.popMatrix();
+
     matrixStack.rotateX(thighX);
 
     // Draw thigh (with pants color)
@@ -47,8 +55,8 @@ void Leg::getLowerLegRotation(float& x) const {
     x = lowerLegX;
 }
 
-LeftLeg::LeftLeg() : Leg(-0.3f, -0.75f, 0.0f) {
+LeftLeg::LeftLeg() : Leg(-0.4f, -1.2f, 0.0f) {
 }
 
-RightLeg::RightLeg() : Leg(0.3f, -0.75f, 0.0f) {
+RightLeg::RightLeg() : Leg(0.4f, -1.2f, 0.0f) {
 }

--- a/sources/Human/Shoulder.cpp
+++ b/sources/Human/Shoulder.cpp
@@ -14,8 +14,8 @@ void Shoulder::render(MatrixStack& matrixStack) {
     matrixStack.popMatrix();
 }
 
-LeftShoulder::LeftShoulder() : Shoulder(-0.7f, 0.5f, 0.0f) {
+LeftShoulder::LeftShoulder() : Shoulder(-0.6f, 1.2f, 0.0f) {
 }
 
-RightShoulder::RightShoulder() : Shoulder(0.7f, 0.5f, 0.0f) {
+RightShoulder::RightShoulder() : Shoulder(0.6f, 1.2f, 0.0f) {
 }


### PR DESCRIPTION
## Summary
- show debug cubes at the local origin of each arm and leg
- align arms, legs, and shoulders with correct torso positions

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_687a6511d3b48331bbb2086bb059955e