### PR TITLE
Fix arm and leg transformations

### DIFF
--- a/sources/Human/Arm.cpp
+++ b/sources/Human/Arm.cpp
@@ -21,9 +21,8 @@ void Arm::render(MatrixStack& matrixStack) {
 
     matrixStack.rotateX(upperArmX);
     matrixStack.rotateZ(upperArmZ);
-    matrixStack.translate(positionX, positionY, positionZ);
 
-    // Debug marker to visualize the shoulder joint position
+    // Debug marker to visualize the shoulder joint position after rotation
     matrixStack.pushMatrix();
     matrixStack.scale(0.05f, 0.05f, 0.05f);
     matrixStack.applyToOpenGL();

--- a/sources/Human/Leg.cpp
+++ b/sources/Human/Leg.cpp
@@ -20,9 +20,8 @@ void Leg::render(MatrixStack& matrixStack) {
     matrixStack.popMatrix();
 
     matrixStack.rotateX(thighX);
-    matrixStack.translate(positionX, positionY, positionZ);
 
-    // Debug marker to visualize the hip joint position
+    // Debug marker to visualize the hip joint position after rotation
     matrixStack.pushMatrix();
     matrixStack.scale(0.05f, 0.05f, 0.05f);
     matrixStack.applyToOpenGL();


### PR DESCRIPTION
## Summary
- remove redundant translations from Arm and Leg rendering
- keep debug markers to visualize joint positions

## Testing
- `make`
- `./humangl` *(fails: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_e_687b73f8b3dc8331b53e9b64520e5a6c