### PR TITLE
Fix hierarchical transformations

### DIFF
--- a/sources/Matrix/Matrix4.cpp
+++ b/sources/Matrix/Matrix4.cpp
@@ -19,7 +19,7 @@ void Matrix4::translate(float x, float y, float z) {
     translation.m[12] = x;
     translation.m[13] = y;
     translation.m[14] = z;
-    *this = translation * *this;
+    *this = *this * translation;
 }
 
 void Matrix4::rotateX(float angle) {
@@ -32,8 +32,8 @@ void Matrix4::rotateX(float angle) {
     rotation.m[6] = s;
     rotation.m[9] = -s;
     rotation.m[10] = c;
-    
-    *this = rotation * *this;
+
+    *this = *this * rotation;
 }
 
 void Matrix4::rotateY(float angle) {
@@ -46,8 +46,8 @@ void Matrix4::rotateY(float angle) {
     rotation.m[2] = -s;
     rotation.m[8] = s;
     rotation.m[10] = c;
-    
-    *this = rotation * *this;
+
+    *this = *this * rotation;
 }
 
 void Matrix4::rotateZ(float angle) {
@@ -60,8 +60,8 @@ void Matrix4::rotateZ(float angle) {
     rotation.m[1] = s;
     rotation.m[4] = -s;
     rotation.m[5] = c;
-    
-    *this = rotation * *this;
+
+    *this = *this * rotation;
 }
 
 void Matrix4::scale(float x, float y, float z) {
@@ -69,7 +69,7 @@ void Matrix4::scale(float x, float y, float z) {
     scaling.m[0] = x;
     scaling.m[5] = y;
     scaling.m[10] = z;
-    *this = scaling * *this;
+    *this = *this * scaling;
 }
 
 Matrix4 Matrix4::operator*(const Matrix4& other) const {


### PR DESCRIPTION
## Summary
- fix `Matrix4` transformation functions to multiply on the right so operations apply in the order called

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_687c9be739ec833189aa097f1dcc8626