### PR TITLE
Fix hierarchical transforms for arms and legs

### DIFF
--- a/sources/Human/Arm.cpp
+++ b/sources/Human/Arm.cpp
@@ -31,8 +31,10 @@ void Arm::render(MatrixStack& matrixStack) {
 
     // Draw upper arm
     matrixStack.pushMatrix();
-    matrixStack.scale(0.3f, 0.8f, 0.3f);
+    // Translate the cube so the shoulder joint lines up before scaling so the
+    // distance is not affected by the scale factor.
     matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.3f, 0.8f, 0.3f);
     matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);  // Skin color for upper arms
     matrixStack.popMatrix();
@@ -40,8 +42,9 @@ void Arm::render(MatrixStack& matrixStack) {
     // Draw forearm (connected to upper arm)
     matrixStack.translate(0.0f, -0.8f, 0.0f);
     matrixStack.rotateX(forearmX);
-    matrixStack.scale(0.25f, 0.8f, 0.25f);
+    // Offset the forearm before scaling so the elbow distance remains constant.
     matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.25f, 0.8f, 0.25f);
     matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);  // Skin color for forearms
 

--- a/sources/Human/Head.cpp
+++ b/sources/Human/Head.cpp
@@ -19,8 +19,10 @@ Neck::Neck() : BodyPartRenderer(0.8f, 0.6f, 0.4f) {
 
 void Neck::render(MatrixStack& matrixStack) {
     matrixStack.pushMatrix();
-    matrixStack.scale(0.3f, 0.3f, 0.3f);
+    // Move the neck to its position on top of the torso first so any scaling
+    // does not alter the translation distance.
     matrixStack.translate(0.0f, 0.9f, 0.0f);
+    matrixStack.scale(0.3f, 0.3f, 0.3f);
     matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
     matrixStack.popMatrix();
@@ -32,10 +34,12 @@ Head::Head() : BodyPartRenderer(0.8f, 0.6f, 0.4f), headRotationX(0.0f), headRota
 
 void Head::render(MatrixStack& matrixStack) {
     matrixStack.pushMatrix();
-    matrixStack.scale(0.6f, 0.6f, 0.6f);
+    // Position the head relative to the neck before applying rotations so that
+    // it pivots around the neck joint rather than the world origin.
+    matrixStack.translate(0.0f, 1.4f, 0.0f);
     matrixStack.rotateX(headRotationX);
     matrixStack.rotateY(headRotationY);
-    matrixStack.translate(0.0f, 1.4f, 0.0f);
+    matrixStack.scale(0.6f, 0.6f, 0.6f);
     matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
     matrixStack.popMatrix();
@@ -57,9 +61,11 @@ Eyes::Eyes() : BodyPartRenderer(0.0f, 0.0f, 0.0f), headRotationX(0.0f), headRota
 
 void Eyes::render(MatrixStack& matrixStack) {
     matrixStack.pushMatrix();
+    // Translate to the head position before applying rotation so the eyes
+    // follow the head movement correctly.
+    matrixStack.translate(0.0f, 1.4f, 0.0f);
     matrixStack.rotateX(headRotationX);
     matrixStack.rotateY(headRotationY);
-    matrixStack.translate(0.0f, 1.4f, 0.0f);
 
     // Left eye
     matrixStack.pushMatrix();

--- a/sources/Human/Leg.cpp
+++ b/sources/Human/Leg.cpp
@@ -30,8 +30,9 @@ void Leg::render(MatrixStack& matrixStack) {
 
     // Draw thigh (with pants color)
     matrixStack.pushMatrix();
-    matrixStack.scale(0.3f, 0.8f, 0.3f);
+    // Offset the thigh so the hip joint remains at the top before scaling.
     matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.3f, 0.8f, 0.3f);
     matrixStack.applyToOpenGL();
     drawColoredCube(0.1f, 0.2f, 0.6f);  // Dark blue pants color for thighs
     matrixStack.popMatrix();
@@ -39,8 +40,9 @@ void Leg::render(MatrixStack& matrixStack) {
     // Draw lower leg (connected to thigh)
     matrixStack.translate(0.0f, -0.8f, 0.0f);
     matrixStack.rotateX(lowerLegX);
-    matrixStack.scale(0.25f, 0.8f, 0.25f);
+    // Translate to align the knee joint before scaling the lower leg.
     matrixStack.translate(0.0f, -0.4f, 0.0f);
+    matrixStack.scale(0.25f, 0.8f, 0.25f);
     matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);  // Skin color for lower legs
 

--- a/sources/Human/Shoulder.cpp
+++ b/sources/Human/Shoulder.cpp
@@ -7,8 +7,10 @@ Shoulder::Shoulder(float x, float y, float z)
 
 void Shoulder::render(MatrixStack& matrixStack) {
     matrixStack.pushMatrix();
-    matrixStack.scale(0.3f, 0.3f, 0.3f);
+    // Translate to the shoulder joint before scaling so the translation is not
+    // affected by the scale factor.
     matrixStack.translate(positionX, positionY, positionZ);
+    matrixStack.scale(0.3f, 0.3f, 0.3f);
     matrixStack.applyToOpenGL();
     drawColoredCube(colorR, colorG, colorB);
     matrixStack.popMatrix();


### PR DESCRIPTION
## Summary
- correct transform order so arms and legs pivot at their joints
- translate before scaling in upper arm, forearm, thigh and lower leg

## Testing
- `make`
- `./humangl` *(fails: XDG_RUNTIME_DIR not set)*

------
https://chatgpt.com/codex/tasks/task_e_687ca94dfdb48331bf074527eb268ca1